### PR TITLE
Add Key attribute mapping test

### DIFF
--- a/oss/tests/PocoMappingTests.cs
+++ b/oss/tests/PocoMappingTests.cs
@@ -40,5 +40,16 @@ namespace KsqlDsl.Tests
 
             Assert.Equal("mapped-topic", topicName);
         }
+
+        [Fact]
+        public void KeyAttribute_Should_Map_ToPartitionKey()
+        {
+            using var context = new MappingKafkaContext();
+
+            var entityModel = context.MappedEntities.GetEntityModel();
+
+            Assert.Single(entityModel.KeyProperties);
+            Assert.Equal(nameof(MappedEntity.Id), entityModel.KeyProperties[0].Name);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend PocoMappingTests to verify `[Key]` attribute mapping

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8daf88648327ae133c69376eea6a