### PR TITLE
Add ForEachAsync timeout unit tests

### DIFF
--- a/oss/tests/eventset_timeout_extensions.cs
+++ b/oss/tests/eventset_timeout_extensions.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace KsqlDsl
+{
+    /// <summary>
+    /// Extension methods for EventSet to support timeout parameter in tests.
+    /// </summary>
+    public static class EventSetTimeoutExtensions
+    {
+        public static async Task ForEachAsync<T>(this EventSet<T> set, Func<T, Task> action, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(timeout);
+            await set.ForEachAsync(action, cts.Token);
+        }
+    }
+}

--- a/oss/tests/for_each_async_timeout_tests.cs
+++ b/oss/tests/for_each_async_timeout_tests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using KsqlDsl;
+using KsqlDsl.Attributes;
+using KsqlDsl.Modeling;
+using KsqlDsl.Options;
+using Xunit;
+
+namespace KsqlDsl.Tests
+{
+    [Topic("timeout-test-events")]
+    public class TimeoutTestEvent
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+
+    public class TimeoutTestContext : KafkaContext
+    {
+        public EventSet<TimeoutTestEvent> Events => Set<TimeoutTestEvent>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Event<TimeoutTestEvent>();
+        }
+
+        protected override void OnConfiguring(KafkaContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseKafka("localhost:9092");
+        }
+    }
+
+    public class ForEachAsyncTimeoutTests
+    {
+        [Fact]
+        public async Task ForEachAsync_WithCancelledToken_Should_ThrowOperationCanceledException()
+        {
+            using var context = new TimeoutTestContext();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                await context.Events.ForEachAsync(_ => Task.CompletedTask, cts.Token));
+        }
+
+        [Fact]
+        public async Task ForEachAsync_WithTimeout_Should_Cancel()
+        {
+            using var context = new TimeoutTestContext();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                await context.Events.ForEachAsync(_ => Task.Delay(50), TimeSpan.FromMilliseconds(1)));
+        }
+
+        [Fact]
+        public async Task ForEachAsync_WithSufficientTimeout_Should_Complete()
+        {
+            using var context = new TimeoutTestContext();
+            int called = 0;
+
+            await context.Events.ForEachAsync(_ => { called++; return Task.CompletedTask; }, TimeSpan.FromSeconds(1));
+
+            Assert.Equal(0, called); // EventSet returns empty list in tests
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add extension for EventSet.ForEachAsync supporting timeout
- add unit tests covering cancellation token and timeout behavior

## Testing
- `dotnet test oss/tests/KsqlDslTests.csproj --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9fe1f8c483278b99cea71b788e28