### PR TITLE
Add ForEachAsync API test

### DIFF
--- a/oss/tests/ForEachAsyncApiTests.cs
+++ b/oss/tests/ForEachAsyncApiTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace KsqlDsl.Tests
+{
+    public class ForEachAsyncApiTests
+    {
+        private class DummyEntity { }
+
+        [Fact]
+        public void EventSet_ForEachAsync_Should_HaveTimeoutOverload()
+        {
+            var eventSetType = typeof(KsqlDsl.EventSet<>).MakeGenericType(typeof(DummyEntity));
+            var methods = eventSetType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+            bool hasTimeoutOverload = methods.Any(m =>
+                m.Name == "ForEachAsync" &&
+                m.GetParameters().Length == 3 &&
+                m.GetParameters()[0].ParameterType == typeof(Func<DummyEntity, Task>) &&
+                m.GetParameters()[1].ParameterType == typeof(TimeSpan) &&
+                m.GetParameters()[2].ParameterType == typeof(CancellationToken));
+
+            Assert.True(hasTimeoutOverload, "ForEachAsync with timeout and CancellationToken overload is missing.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- verify that EventSet offers a ForEachAsync overload accepting timeout

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebbb79ad483279cf6f563da6a81ba